### PR TITLE
Ini scanner mode

### DIFF
--- a/docs/book/reader.md
+++ b/docs/book/reader.md
@@ -45,7 +45,8 @@ function. Please review this documentation to be aware of its specific behaviors
 
 > ### Process Sections
 >
-> By default, the INI reader executes `parse_ini_file()`  with the optional parameter `$process_sections` being `true`. The result is a multidimensional array, with the section names and settings included.
+> By default, the INI reader executes `parse_ini_file()`  with the optional parameter `$process_sections` being `true`.
+> The result is a multidimensional array, with the section names and settings included.
 >
 > To merge sections, set the parameter via `setProcessSections()` to `false` as follows.
 >
@@ -56,7 +57,8 @@ function. Please review this documentation to be aware of its specific behaviors
 
 > ### Typed Mode
 >
-> By default, the INI reader executes `parse_ini_file()`  with the optional parameter `$scanner_mode` set to `INI_SCANNER_NORMAL`. This results in all config values being returned as strings.
+> By default, the INI reader executes `parse_ini_file()`  with the optional parameter `$scanner_mode` set to `INI_SCANNER_NORMAL`.
+> This results in all config values being returned as strings.
 >
 > To automatically return integer, boolean, and null values as the appropriate types, switch to typed mode with `setTypedMode()`, and `parse_ini_file()` will be called with `INI_SCANNER_TYPED` instead.
 >

--- a/docs/book/reader.md
+++ b/docs/book/reader.md
@@ -54,6 +54,17 @@ function. Please review this documentation to be aware of its specific behaviors
 > $reader->setProcessSections(false);
 > ```
 
+> ### Typed Mode
+>
+> By default, the INI reader executes `parse_ini_file()`  with the optional parameter `$scanner_mode` set to `INI_SCANNER_NORMAL`. This results in all config values being returned as strings.
+>
+> To automatically return integer, boolean, and null values as the appropriate types, switch to typed mode with `setTypedMode()`, and `parse_ini_file()` will be called with `INI_SCANNER_TYPED` instead.
+>
+> ```php
+> $reader = new Laminas\Config\Reader\Ini();
+> $reader->setTypedMode(true);
+> ```
+
 The following example illustrates basic usage of `Laminas\Config\Reader\Ini` for
 loading configuration data from an INI file. In this example, configuration data
 for both a production system and for a staging system exists.

--- a/src/Reader/Ini.php
+++ b/src/Reader/Ini.php
@@ -55,6 +55,15 @@ class Ini implements ReaderInterface
     protected $processSections = true;
 
     /**
+     * Flag which determines whether boolean, null, and integer values should be
+     * returned as their proper types.
+     *
+     * @see https://www.php.net/parse_ini_file
+     * @var bool
+     */
+    protected $typedMode = false;
+
+    /**
      * Set nest separator.
      *
      * @param  string $separator
@@ -105,6 +114,44 @@ class Ini implements ReaderInterface
     }
 
     /**
+     * Set whether boolean, null, and integer values should be returned as their proper types.
+     * When set to false, all values will be returned as strings.
+     *
+     * @see https://www.php.net/parse_ini_file
+     * @param bool $typedMode
+     * @return $this
+     */
+    public function setTypedMode($typedMode)
+    {
+        $this->typedMode = (bool) $typedMode;
+        return $this;
+    }
+
+    /**
+     * Get whether boolean, null, and integer values should be returned as their proper types.
+     * When set to false, all values will be returned as strings.
+     *
+     * @see https://www.php.net/parse_ini_file
+     * @return bool
+     */
+    public function getTypedMode()
+    {
+        return $this->typedMode;
+    }
+
+    /**
+     * Get the scanner-mode constant value to be used with the built-in parse_ini_file function.
+     * Either INI_SCANNER_NORMAL or INI_SCANNER_TYPED depending on $typedMode.
+     *
+     * @see https://www.php.net/parse_ini_file
+     * @return int
+     */
+    public function getScannerMode()
+    {
+        return $this->getTypedMode() ? INI_SCANNER_TYPED : INI_SCANNER_NORMAL;
+    }
+
+    /**
      * fromFile(): defined by Reader interface.
      *
      * @see    ReaderInterface::fromFile()
@@ -132,7 +179,7 @@ class Ini implements ReaderInterface
             },
             E_WARNING
         );
-        $ini = parse_ini_file($filename, $this->getProcessSections());
+        $ini = parse_ini_file($filename, $this->getProcessSections(), $this->getScannerMode());
         restore_error_handler();
 
         return $this->process($ini);
@@ -161,7 +208,7 @@ class Ini implements ReaderInterface
             },
             E_WARNING
         );
-        $ini = parse_ini_string($string, $this->getProcessSections());
+        $ini = parse_ini_string($string, $this->getProcessSections(), $this->getScannerMode());
         restore_error_handler();
 
         return $this->process($ini);

--- a/src/Reader/Ini.php
+++ b/src/Reader/Ini.php
@@ -121,9 +121,9 @@ class Ini implements ReaderInterface
      * @param bool $typedMode
      * @return $this
      */
-    public function setTypedMode($typedMode)
+    public function setTypedMode(bool $typedMode): Ini
     {
-        $this->typedMode = (bool) $typedMode;
+        $this->typedMode = $typedMode;
         return $this;
     }
 
@@ -134,7 +134,7 @@ class Ini implements ReaderInterface
      * @see https://www.php.net/parse_ini_file
      * @return bool
      */
-    public function getTypedMode()
+    public function getTypedMode(): bool
     {
         return $this->typedMode;
     }
@@ -146,7 +146,7 @@ class Ini implements ReaderInterface
      * @see https://www.php.net/parse_ini_file
      * @return int
      */
-    public function getScannerMode()
+    public function getScannerMode(): int
     {
         return $this->getTypedMode() ? INI_SCANNER_TYPED : INI_SCANNER_NORMAL;
     }

--- a/src/Reader/Ini.php
+++ b/src/Reader/Ini.php
@@ -118,10 +118,8 @@ class Ini implements ReaderInterface
      * When set to false, all values will be returned as strings.
      *
      * @see https://www.php.net/parse_ini_file
-     * @param bool $typedMode
-     * @return $this
      */
-    public function setTypedMode(bool $typedMode): Ini
+    public function setTypedMode(bool $typedMode): self
     {
         $this->typedMode = $typedMode;
         return $this;
@@ -132,7 +130,6 @@ class Ini implements ReaderInterface
      * When set to false, all values will be returned as strings.
      *
      * @see https://www.php.net/parse_ini_file
-     * @return bool
      */
     public function getTypedMode(): bool
     {
@@ -144,7 +141,6 @@ class Ini implements ReaderInterface
      * Either INI_SCANNER_NORMAL or INI_SCANNER_TYPED depending on $typedMode.
      *
      * @see https://www.php.net/parse_ini_file
-     * @return int
      */
     public function getScannerMode(): int
     {

--- a/test/Reader/IniTest.php
+++ b/test/Reader/IniTest.php
@@ -203,4 +203,74 @@ ECS;
         self::assertEquals('foo', $arrayIni['production_key']);
         self::assertEquals('bar', $arrayIni['staging_key']);
     }
+
+    public function testFromFileWithoutTypes()
+    {
+        $arrayIni = $this->reader->fromFile($this->getTestAssetPath('types'));
+
+        self::assertSame('Bob Smith', $arrayIni['production']['name']);
+        self::assertSame('55', $arrayIni['production']['age']);
+        self::assertSame('55', $arrayIni['production']['age_str']);
+        self::assertSame('1', $arrayIni['production']['is_married']);
+        self::assertSame('', $arrayIni['production']['is_employed']);
+        self::assertSame('', $arrayIni['production']['employer']);
+    }
+
+    public function testFromFileWithTypes()
+    {
+        $reader = $this->reader;
+        $reader->setTypedMode(true);
+        $arrayIni = $reader->fromFile($this->getTestAssetPath('types'));
+
+        self::assertSame('Bob Smith', $arrayIni['production']['name']);
+        self::assertSame(55, $arrayIni['production']['age']);
+        self::assertSame('55', $arrayIni['production']['age_str']);
+        self::assertSame(true, $arrayIni['production']['is_married']);
+        self::assertSame(false, $arrayIni['production']['is_employed']);
+        self::assertSame(null, $arrayIni['production']['employer']);
+    }
+
+    public function testFromStringWithoutTypes()
+    {
+        $ini = <<<ECS
+[production]
+name="Bob Smith"
+age=55
+age_str="55"
+is_married=yes
+is_employed=FALSE
+employer=null
+ECS;
+        $arrayIni = $this->reader->fromString($ini);
+
+        self::assertSame('Bob Smith', $arrayIni['production']['name']);
+        self::assertSame('55', $arrayIni['production']['age']);
+        self::assertSame('55', $arrayIni['production']['age_str']);
+        self::assertSame('1', $arrayIni['production']['is_married']);
+        self::assertSame('', $arrayIni['production']['is_employed']);
+        self::assertSame('', $arrayIni['production']['employer']);
+    }
+
+    public function testFromStringWithTypes()
+    {
+        $ini = <<<ECS
+[production]
+name="Bob Smith"
+age=55
+age_str="55"
+is_married=yes
+is_employed=FALSE
+employer=null
+ECS;
+        $reader = $this->reader;
+        $reader->setTypedMode(true);
+        $arrayIni = $reader->fromString($ini);
+
+        self::assertSame('Bob Smith', $arrayIni['production']['name']);
+        self::assertSame(55, $arrayIni['production']['age']);
+        self::assertSame('55', $arrayIni['production']['age_str']);
+        self::assertSame(true, $arrayIni['production']['is_married']);
+        self::assertSame(false, $arrayIni['production']['is_employed']);
+        self::assertSame(null, $arrayIni['production']['employer']);
+    }
 }

--- a/test/Reader/IniTest.php
+++ b/test/Reader/IniTest.php
@@ -233,14 +233,14 @@ ECS;
     public function testFromStringWithoutTypes()
     {
         $ini = <<<ECS
-[production]
-name="Bob Smith"
-age=55
-age_str="55"
-is_married=yes
-is_employed=FALSE
-employer=null
-ECS;
+            [production]
+            name="Bob Smith"
+            age=55
+            age_str="55"
+            is_married=yes
+            is_employed=FALSE
+            employer=null
+            ECS;
         $arrayIni = $this->reader->fromString($ini);
 
         self::assertSame('Bob Smith', $arrayIni['production']['name']);
@@ -254,14 +254,14 @@ ECS;
     public function testFromStringWithTypes()
     {
         $ini = <<<ECS
-[production]
-name="Bob Smith"
-age=55
-age_str="55"
-is_married=yes
-is_employed=FALSE
-employer=null
-ECS;
+            [production]
+            name="Bob Smith"
+            age=55
+            age_str="55"
+            is_married=yes
+            is_employed=FALSE
+            employer=null
+            ECS;
         $reader = $this->reader;
         $reader->setTypedMode(true);
         $arrayIni = $reader->fromString($ini);

--- a/test/Reader/TestAssets/Ini/types.ini
+++ b/test/Reader/TestAssets/Ini/types.ini
@@ -1,0 +1,7 @@
+[production]
+name="Bob Smith"
+age=55
+age_str="55"
+is_married=yes
+is_employed=FALSE
+employer=null


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | yes

### Description
Adds a `typedMode` flag to the INI Reader to support the built-in `INI_SCANNER_TYPED` flag on `parse_ini_file()`.
This allows integer, boolean, and null values to be returned as the appropriate types, rather than all being returned as strings.
