### PR TITLE
Fix returned value of `Laminas\Config\Processor\Queue#process()` to comply with interface declaration

### DIFF
--- a/src/Processor/Queue.php
+++ b/src/Processor/Queue.php
@@ -31,6 +31,8 @@ class Queue extends PriorityQueue implements ProcessorInterface
             /** @var $parser ProcessorInterface */
             $parser->process($config);
         }
+
+        return $config;
     }
 
     /**


### PR DESCRIPTION
`Laminas\Config\Processor\Queue` implements `Laminas\Config\Processor\ProcessorInterface`, but lying about return value on `process()` method.