### PR TITLE
Add support for `psr/container:^2.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,6 @@
     },
     "scripts": {
         "check": [
-            "@license-check",
             "@cs-check",
             "@test"
         ],

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
         "ext-json": "*",
         "laminas/laminas-stdlib": "^3.6",
-        "psr/container": "^1.0"
+        "psr/container": "^1.0 || ^2.0"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~2.4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b2d2aec8c48ae125b566ab999322a7e1",
+    "content-hash": "2f6591adc46c3fffd026d08c6a38f8a3",
     "packages": [
         {
             "name": "laminas/laminas-stdlib",

--- a/test/ConfigTest.php
+++ b/test/ConfigTest.php
@@ -22,6 +22,21 @@ use function range;
  */
 class ConfigTest extends TestCase
 {
+    /** @var array */
+    protected $all;
+    /** @var array */
+    protected $numericData;
+    /** @var array */
+    protected $menuData1;
+    /** @var array */
+    protected $toCombineA;
+    /** @var array */
+    protected $toCombineB;
+    /** @var array */
+    protected $leadingdot;
+    /** @var array */
+    protected $invalidkey;
+
     protected function setUp(): void
     {
         // Arrays representing common config configurations

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -43,10 +43,10 @@ class FactoryTest extends TestCase
      */
     protected function getTestAssetFileName($ext)
     {
-        if (empty($this->tmpfiles[$ext])) {
-            $this->tmpfiles[$ext] = tempnam(sys_get_temp_dir(), 'laminas-config-writer') . '.' . $ext;
+        if (empty($this->tmpFiles[$ext])) {
+            $this->tmpFiles[$ext] = tempnam(sys_get_temp_dir(), 'laminas-config-writer') . '.' . $ext;
         }
-        return $this->tmpfiles[$ext];
+        return $this->tmpFiles[$ext];
     }
 
     protected function setUp(): void


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Allow `psr/container` both v1 and v2 to be more future proof. Also I fixed some dynamic property definition in the tests.