### PR TITLE
Fix markdownlint issues in docs

### DIFF
--- a/docs/book/factory.md
+++ b/docs/book/factory.md
@@ -6,7 +6,7 @@ array or to a `Laminas\Config\Config` object. The factory has two purposes
 - Loading configuration file(s)
 - Storing a configuration file
 
-<!-- markdownlint-disable-next-line header-increment -->
+<!-- markdownlint-disable-next-line heading-increment -->
 > ### Storage writes to a single file
 >
 > Storing the configuration always writes to a **single** file. The factory is

--- a/docs/book/processor.md
+++ b/docs/book/processor.md
@@ -12,7 +12,7 @@ laminas-config provides the following concrete implementations:
 - `Laminas\Config\Processor\Token`: find and replace specific tokens.
 - `Laminas\Config\Processor\Translator`: translate configuration values in other languages using `Laminas\I18n\Translator`.
 
-<!-- markdownlint-disable-next-line header-increment -->
+<!-- markdownlint-disable-next-line heading-increment -->
 > ### What gets processed?
 >
 > Typically, you will process configuration _values_. However, there are use
@@ -116,7 +116,7 @@ echo $config->foo;
 ```
 
 This example returns the output: `bar`. The filters in the queue are applied in
-*FIFO* (First In, First Out) order .
+_FIFO_ (First In, First Out) order .
 
 ## Laminas\\Config\\Processor\\Token
 

--- a/docs/book/reader.md
+++ b/docs/book/reader.md
@@ -14,7 +14,7 @@ concrete implementations of this interface are:
 `fromFile()` and `fromString()` are expected to return a PHP array containing
 the data from the specified configuration.
 
-<!-- markdownlint-disable-next-line header-increment -->
+<!-- markdownlint-disable-next-line heading-increment -->
 > ### Differences from Zend Framework 1
 >
 > The `Laminas\Config\Reader` component no longer supports the following features:

--- a/docs/book/theory.md
+++ b/docs/book/theory.md
@@ -14,7 +14,7 @@ is itself an array, then the resulting object property is created as a new
 recursively, such that a hierarchy of configuration data may be created with any
 number of levels.
 
-<!-- markdownlint-disable-next-line header-increment -->
+<!-- markdownlint-disable-next-line heading-increment -->
 > ### Extending `Laminas\Config\Config` class
 >
 > If you decide to extend `Laminas\Config\Config` class, each property (subnode)


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Assuming the current release is 1.5.0, the next patch release is 1.5.1, the next minor is 1.6.0 and the next major is 2.0.0, The Current release branch will be `1.5.x`, the next minor branch will be `1.6.x`, and the next major branch will be `2.0.x`

Pick the target branch based on the following criteria:
  * Documentation improvement: Current release branch 1.5.x
  * Bugfix: Current release branch 1.5.x
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: Next minor 1.6.x
  * New feature, or refactor of existing code: Next minor 1.6.x
  * Backwards incompatible features and refactoring: Next major 2.0.x

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This PR fixes some issues reported by mardownlint when checking the documentation files:

* Suppressed `header-increment` rules replaced with `heading-increment`. This is likely related with a change in a recent markdownlint version.
* Changed usage of `*` with `_` for italic. 
